### PR TITLE
Upgrade/Add JDK Versions to build different mc versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.7-stretch as build
+ARG JDK_VERSION="17"
+ARG PYTHON_VERSION_TAG="3.7-stretch"
+
+FROM python:${PYTHON_VERSION_TAG} as build
 
 WORKDIR /build/rcon
 
@@ -8,8 +11,7 @@ RUN python3 -m pip install -r requirements.txt &&\
     python3 -m pip install pyinstaller
 RUN pyinstaller rconclient/main.py --onefile
 
-
-FROM openjdk:17-jdk-bullseye as final
+FROM openjdk:${JDK_VERSION}-jdk-bullseye AS final
 
 LABEL maintainer="zekro <contact@zekro.de>" \
       version="2.0.0" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pyinstaller rconclient/main.py --onefile
 FROM openjdk:11.0.3-jdk-stretch as final
 
 LABEL maintainer="zekro <contact@zekro.de>" \
-      version="1.0.0" \
+      version="2.0.0" \
       description="Minecraft spigot dockerized autobuilding latest version on startup"
 
 COPY --from=build /build/rcon/dist/main /usr/bin/rconcli

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN python3 -m pip install -r requirements.txt &&\
 RUN pyinstaller rconclient/main.py --onefile
 
 
-FROM openjdk:11.0.3-jdk-stretch as final
+FROM openjdk:11-jdk as final
 
 LABEL maintainer="zekro <contact@zekro.de>" \
       version="2.0.0" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN python3 -m pip install -r requirements.txt &&\
 RUN pyinstaller rconclient/main.py --onefile
 
 
-FROM openjdk:11-jdk as final
+FROM openjdk:17-jdk-bullseye as final
 
 LABEL maintainer="zekro <contact@zekro.de>" \
       version="2.0.0" \

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ services:
 ```
 
 ## Version Selection
+### Branches and Docker Hub Tags
+Branches and tags are named the same. To build a Minecraft version that requires the JDK-8, the branch `jdk8` must be used. This branch is also available as a  image on Docker Hub under `spigot-autobuild:jdk8`.
+
 The version 1.16 is not available, but all other patch versions from the 1.16 are available. So `1.16.1`, `1.16.2`, `1.16.3`...  
 Version `1.17` (not `1.17.X`) is only executable with Java 16, which is not supported in this project.
 ### JDK-8
@@ -71,15 +74,20 @@ Version `1.17` (not `1.17.X`) is only executable with Java 16, which is not supp
 - 1.15
 - 1.16(.1)
 
+Branch: `jdk8`
+
 ### JDK-11
 - 1.13
 - 1.14
 - 1.15
 - 1.16(.1)
+  
+Branch: `jdk11`
 
 ### JDK-17
 - 1.17.1
 
+Branch: `jdk17`
 ## Build Caching?
 
 Defaultly, `BUILD_CACHING` is enabled which builds the `spigot.jar` on first startup and saves the commit hash of this build in a save file inside the container. Next time you start the container, the saved hash will be compared with the has of the latest available version. Only if they differ, a new build will be started. Else, the previously built `spigot.jar` inside the container will be used.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In contrast to [spigot-dockerized](https://github.com/zekroTJA/spigot-dockerized
 ## How To Use
 
 You can pull the image from [dockerhub](https://hub.docker.com/r/zekro/spigot-autobuild) or [build it yourself](#build-it-yourself).  
-The `latest` image is also always the master branch and uses the latest LTS JDK version.
+The `latest` image is also always the master branch and uses the latest LTS JDK version by default.
 Choose the [right version](#version-selection) for your minecraft version.
 ```
 $ docker pull zekro/spigot-autobuild:latest
@@ -60,11 +60,11 @@ services:
 ```
 
 ## Version Selection
-### Branches and Docker Hub Tags
-Branches and tags are named the same. To build a Minecraft version that requires the JDK-8, the branch `jdk8` must be used. This branch is also available as a  image on Docker Hub under `spigot-autobuild:jdk8`.
+### Docker Hub Tags
+To build a Minecraft version that requires the JDK-8, the build argument `JDK_VERSION: 8` must be used. This Version is also available as a image on Docker Hub under `spigot-autobuild:jdk8`.
 
 The version 1.16 is not available, but all other patch versions from the 1.16 are available. So `1.16.1`, `1.16.2`, `1.16.3`...  
-Version `1.17` (not `1.17.X`) is only executable with Java 16, which is not supported in this project.
+Version `1.17` (not `1.17.X`) is only executable with Java 16 (no LTS).
 ### JDK-8
 - 1.9
 - 1.10
@@ -75,20 +75,20 @@ Version `1.17` (not `1.17.X`) is only executable with Java 16, which is not supp
 - 1.15
 - 1.16(.1)
 
-Branch: `jdk8`
 
 ### JDK-11
 - 1.13
 - 1.14
 - 1.15
 - 1.16(.1)
-  
-Branch: `jdk11`
+
+### JDK-16
+- 1.17
+- 1.17.1
 
 ### JDK-17
 - 1.17.1
 
-Branch: `jdk17`
 ## Build Caching?
 
 Defaultly, `BUILD_CACHING` is enabled which builds the `spigot.jar` on first startup and saves the commit hash of this build in a save file inside the container. Next time you start the container, the saved hash will be compared with the has of the latest available version. Only if they differ, a new build will be started. Else, the previously built `spigot.jar` inside the container will be used.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In contrast to [spigot-dockerized](https://github.com/zekroTJA/spigot-dockerized
 ## How To Use
 
 You can pull the image from [dockerhub](https://hub.docker.com/r/zekro/spigot-autobuild) or [build it yourself](#build-it-yourself).
-
+Choose the [right version](#version-selection) for your minecraft version.
 ```
 $ docker pull zekro/spigot-autobuild:latest
 ```
@@ -57,6 +57,28 @@ services:
       - './spigot/locals:/etc/mcserver/locals'
 
 ```
+
+## Version Selection
+The version 1.16 is not available, but all other patch versions from the 1.16 are available. So `1.16.1`, `1.16.2`, `1.16.3`...  
+Version `1.17` (not `1.17.X`) is only executable with Java 16, which is not supported in this project.
+### JDK-8
+- 1.9
+- 1.10
+- 1.11
+- 1.12
+- 1.13
+- 1.14
+- 1.15
+- 1.16(.1)
+
+### JDK-11
+- 1.13
+- 1.14
+- 1.15
+- 1.16(.1)
+
+### JDK-17
+- 1.17.1
 
 ## Build Caching?
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ In contrast to [spigot-dockerized](https://github.com/zekroTJA/spigot-dockerized
 
 ## How To Use
 
-You can pull the image from [dockerhub](https://hub.docker.com/r/zekro/spigot-autobuild) or [build it yourself](#build-it-yourself).
+You can pull the image from [dockerhub](https://hub.docker.com/r/zekro/spigot-autobuild) or [build it yourself](#build-it-yourself).  
+The `latest` image is also always the master branch and uses the latest LTS JDK version.
 Choose the [right version](#version-selection) for your minecraft version.
 ```
 $ docker pull zekro/spigot-autobuild:latest


### PR DESCRIPTION
This PR changes the JDK version in the Master Branch to be able to build the latest Minecraft version. Furthermore, the project has been modified so that it is possible to use a different JDK version and thus build other MC versions based on the different branches.

> See conversation below!

# Maintainer TODO
- Copy also the branches JDK8, JDK11 and JDK17 from my project (old)
- Push each branch under its respective tag as a new Docker image. See Branch Tag Names

## Branch Tag Names (old)
Branch -> Tag Name
`master` -> `latest`
`jdk8` -> `jdk8`
`jdk11` -> `jdk11`
`jdk17` -> `jdk17`
JDK17 and master are identical, but should still have both tags for usage reasons