### PR TITLE
User github repository name instead of fixed string

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,6 +29,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Lowercase repo name
+        run: echo "REPO=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
       - name: Build & Push
         uses: docker/build-push-action@v2
         with:
@@ -38,4 +40,4 @@ jobs:
           build-args: |-
             JDK_VERSION=${{ matrix.jdkversion }}
           tags: |-
-            ghcr.io/zekrotja/spigot-autobuild:jdk-${{ matrix.jdkversion }}
+            ghcr.io/${{ env.REPO }}:jdk-${{ matrix.jdkversion }}


### PR DESCRIPTION
I use an intermediate step to convert the username and repo name to lowercase.
The Github Docker Registry does not allow the name or image to start with an uppercase letter.
With zekro/spitgot-autobuild this is no problem but with forks.

``${VAR,,}`` converts the string to lowercase.