### PR TITLE
Add new JDK version 21

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ jobs:
           - "11"
           - "16"
           - "17"
+          - "21"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Version `1.17` (not `1.17.X`) is only executable with Java 16 (no LTS).
 
 ### JDK-17
 - 1.17.1
+- 1.18
+- 1.19
+- 1.20
+
+### JDK-21
+- 1.20
+- 1.21
 
 ## Build Caching?
 


### PR DESCRIPTION
These changes add Java version 21 to the build matrix. I have also added the list of compatible Java/Minecraft versions.